### PR TITLE
Update Treasure_Chest_remix.scad

### DIFF
--- a/Treasure_Chest_remix/Treasure_Chest_remix.scad
+++ b/Treasure_Chest_remix/Treasure_Chest_remix.scad
@@ -263,7 +263,7 @@ module new_hinge_frame_inserts() {
     union() {
         %_hinge_frame();
 
-        translate([20.435, 81.438, 52.25])
+        translate([20.935, 81.438, 52.25])
         rotate([0, 90, 0])
         tube(od, oh, wall, $fn=40);
 


### PR DESCRIPTION
fixed a typo in the x coordinate of the first hinge - was 20.435 instead of 20.935 and that made the left hinge stuck.